### PR TITLE
[chore] Update git policy

### DIFF
--- a/commits.md
+++ b/commits.md
@@ -1,100 +1,71 @@
 <!--
- - SPDX-FileCopyrightText: 2021 Union (This guide originally created by Serokell <https://serokell.io/>)
- -
+ - SPDX-FileCopyrightText: 2021-2022 Union
  - SPDX-License-Identifier: MPL-2.0
  -->
 
-## Branches and pull requests
+## Branches
 
-1. The `master` branch:
+1. The `master` branch is only primary branch:
     1. The code in the `master` branch SHOULD always compile and pass all tests.
     2. The documentation in the `master` branch SHOULD always be up-to-date.
 
 2. Issue branches:
-    1. Naming scheme: `<username>/<issue_id>-<brief_description>`.
+    1. Naming scheme: `<username>/<issue_id>-<brief_description>`; in case there is no issue associated with a branch: `<username>/<brief_description>`.
     2. Make sure the description is really brief but clear enough so that it is easy to understand what the issue is about without looking it up in the issue tracker (assuming that you are familiar with existing issues).
 
     Examples:
     - `worm2fed/#1-example-issue`
     - `rexolion/#1234-ui-for-inputs`
-
-3. Pull requests:
-    1. Each pull request SHOULD resolve exactly one issue.
-    2. Try to avoid too big PRs. If your PR has more than 500 additions + deletions, please think twice whether it can be split into smaller PRs.
-    3. PR title SHOULD adhere to the following scheme: `[ISSUE-ID] Brief description`.
-    4. PR description MUST NOT be empty. If there is a PR template, PR description MUST adhere to this template. If there is no template, please describe the changes you've made and **why** you've made them. Also, provide links to related issues.
-    5. You SHOULD request a review from at least one person you think would be most suitable as reviewers. You MAY request a review from more people if the changes are substantial – use your discretion.
-    6. Keep in mind that review might be automatically requested from codeowners when you actually create a PR. Make sure to review list of reviewers after pressing the `Create pull request` button.
-
-## Commit history
-
-1. An ideal commit history should satisfy the following criteria:
-    1. Each commit MUST adhere to the commit guidelines (#3).
-    2. Each commit SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
-    3. Each commit SHOULD NOT fix a problem introduced by an earlier commit in your pull request or revert an earlier commit in your PR.
-    4. Each commit SHOULD be signed.
-    5. Your pull request generally shouldn't contain changes unrelated to the issue it solves. However, if you modify some file and see an obvious small mistake there (e. g. a typo or wrong formatting), you MAY fix it in your PR.
-
-2. Upon submitting a pull request, ensure the commit history satisfies the criteria listed in 2.1.
-
-3. During the PR review:
-    1. Make changes in separate commits, even if such commits do not comply with 2.1 or 3.
-    2. You MUST NOT amend the previous commits.
-    3. You SHOULD NOT use force-push unless you're pushing the same commits rebased on the newer version of the target branch.
-    4. You SHOULD periodically synchronize your issue branch with the target branch.
-    5. You SHOULD use rebase to synchronize the branches.
-    6. You SHOULD NOT use "Update branch" or merge to synchronize the branches unless rebasing is prohibitively hard.
-
-4. After passing the review but before merging:
-    1. Rebase your changes on the target branch.
-    2. Use the interactive rebase to prettify the commit history so that it adheres to 2.1.
-
-5. Merging the changes:
-    1. If you want to merge someone else's PR, you SHOULD make sure the author is fine with merging and does not want to do anything with the commit history.
-    2. You MUST create a merge commit, i.e. you MUST NOT use neither fast-forward merge nor "squash and merge".
+    - `worm2fed/git-policy`
 
 ## Commit messages
 
-1. The rules in this section apply to:
-    1. Commits that a PR contains upon submission.
-    2. Commits that are going to be merged into the target branch.
+1. We use [Conventional Commits](https://www.conventionalcommits.org/) approach, it provides an easy set of rules for creating an explicit commit history.
 
-2. Each commit message MUST have a subject line (header) and a body, separated with a blank line.
+2. The commit message should be structured as follows:
+    ```
+    <type>([optional scope]): <description>
 
-3. Subject line:
-    1. Prefix the subject line with IDs of all relevant issues: `[#1] Title` if they are accessible by all people with access to the repository.
-    2. Start with an uppercase letter
-    3. Try to limit the subject line to 50 characters; the hard limit is 72 characters
-    4. Do not end the subject line with a period
-    5. Use the imperative mood in the subject line
+    [optional body]
 
-4. Message body:
-    1. Start with `Problem:` and describe a problem that the commit solves
-    2. Continue with `Solution:` and describe how the commit addresses the problem
-    3. Add additional context if you wish
+    [optional footer(s)]
+    ```
 
-      Examples:
-      - GOOD:
-          ```
-          [#453] Switch from avada-kedavra to expelliarmus
+3. The commit contains the following structural elements, to communicate intent to the consumers:
+    1. `fix`: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
+    2. `feat`: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
+    3. `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a `!` after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A `BREAKING CHANGE` can be part of commits of any type.
+    4. Types other than `fix:` and `feat:` are allowed: `ci:`, `docs:`, `style:`, `refactor:` and `test:`.
+    5. Footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
+    6. Additional types are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE). A scope may be provided to a commit’s type, to provide additional contextual information and is contained within parenthesis, e.g., feat(parser): add ability to parse arrays.
 
-          Problem: `avada-kedavra` library that we use to kill unwanted
-          process instances has a negative side-effect: it tears
-          programmers' souls apart. There's currently no mitigation
-          of this issue according to: (link to the developer issue
-          tracker).
+## Pull requests
 
-          Solution: Use a simpler `expelliarmus` library that blocks
-          process instances from performing any effects. Garbage-collect
-          blocked processes using the `kill` syscall.
+1. Each pull request SHOULD resolve exactly one issue.
 
-          ```
-      - BAD:
-          - `[#453] Switch from avada-kedavra to expelliarmus`
-          - `[#453] Change the killer lib`
-          - `[#453] Get rid of avada-kedavra in favor of expelliarmus because the former has some negative side-effects that are too long to explain in the commit header`
-          - ```
-            [#453] Update killer
-            Problem: we need a new lib
-            Solution: switch to the new lib`
-            ```
+2. Try to avoid too big PRs. If your PR has more than 500 additions + deletions, please think twice whether it can be split into smaller PRs.
+
+3. PR title SHOULD adhere to the following scheme: `[ISSUE-ID] Brief description`; in case there is no issue associated with a PR: `[chore] Brief description`.
+
+4. PR description MUST NOT be empty. If there is a PR template, PR description MUST adhere to this template. If there is no template, please describe the changes you've made and **why** you've made them. Also, provide links to related issues.
+
+5. You SHOULD request a review from at least one person you think would be most suitable as reviewers. You MAY request a review from more people if the changes are substantial – use your discretion.
+
+6. Upon submitting a pull request, ensure the commit history satisfies the following criteria:
+    1. Each commit SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
+    2. Each commit SHOULD NOT fix a problem introduced by an earlier commit in your pull request or revert an earlier commit in your PR (you can use fixups for that).
+    3. Each commit SHOULD be signed.
+    4. Your pull request generally shouldn't contain changes unrelated to the issue it solves. However, if you modify some file and see an obvious small mistake there (e. g. a typo or wrong formatting), you MAY fix it in your PR.
+
+7. During the PR review:
+    1. Make changes in separate commits, even if such commits do not comply with this policy.
+    2. You MUST NOT amend the previous commits.
+    3. You SHOULD use rebase to synchronize the branches, you SHOULD NOT use "Update branch" or merge to synchronize the branches unless rebasing is prohibitively hard.
+
+8. After passing the review but before merging:
+    1. Rebase your changes on the target branch.
+    2. Use the interactive rebase to prettify the commit history so that it adheres to this policy.
+
+9. Merging the changes:
+    1. If you want to merge someone else's PR, you SHOULD make sure the author is fine with merging and does not want to do anything with the commit history.
+    2. You MUST create a merge commit, i.e. you MUST NOT use neither fast-forward merge nor "squash and merge".


### PR DESCRIPTION
Problem:
It's too strict for now.. we have to always put commit body, even if there is noting to say, so solution is always duplicating problem in other words...

Solution:
Now we should adhere conventional commits:
- body is optional
- there should be type of changes in title
- no need to put issue number in each commit